### PR TITLE
fix: error when pushing to root folder.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,9 +35,16 @@ fi
 
 echo "Copying contents to git repo"
 # shellcheck disable=SC2115
-rm -rf "$CLONE_DIR/$INPUT_DESTINATION_FOLDER/"
-mkdir -p "$CLONE_DIR/$INPUT_DESTINATION_FOLDER/"
-cp -a "$INPUT_SOURCE_FOLDER/." "$CLONE_DIR/$INPUT_DESTINATION_FOLDER/"
+if [ -z $INPUT_DESTINATION_FOLDER ]
+then
+  rm -rf "$CLONE_DIR/"*
+  cp -r "$INPUT_SOURCE_FOLDER/"* "$CLONE_DIR/"
+else
+  rm -rf "$CLONE_DIR/$INPUT_DESTINATION_FOLDER/"
+  mkdir -p "$CLONE_DIR/$INPUT_DESTINATION_FOLDER/"
+  cp -a "$INPUT_SOURCE_FOLDER/." "$CLONE_DIR/$INPUT_DESTINATION_FOLDER/"
+fi
+
 cd "$CLONE_DIR"
 
 echo "Adding git commit"


### PR DESCRIPTION
When the `INPUT_DESTINATION_FOLDER` is not specified, there is a bug that deletes the repository. See #4

To resolve this, this commit adds a check to see if the destination is undefined. If this is the case, it instead deletes the contents of the repository and copies the contents of the directory.